### PR TITLE
Fixed support for 6.05 vesc firmware beta

### DIFF
--- a/g30_dash.lisp
+++ b/g30_dash.lisp
@@ -82,17 +82,17 @@
 (defun adc-input(buffer) ; Frame 0x65
     {
         (let ((current-speed (* (get-speed) 3.6))
-            (throttle (/(bufget-u8 uart-buf 5) 255.0))
-            (brake (/(bufget-u8 uart-buf 6) 255.0)))
+            (throttle (/(bufget-u8 uart-buf 5) 77.2)) ; 255/3.3 = 77.2
+            (brake (/(bufget-u8 uart-buf 6) 77.2)))
             {
                 (if (< throttle 0)
                     (setf throttle 0))
-                (if (> throttle 1)
-                    (setf throttle 1))
+                (if (> throttle 3.3)
+                    (setf throttle 3.3))
                 (if (< brake 0)
                     (setf brake 0))
-                (if (> brake 1)
-                    (setf brake 1))
+                (if (> brake 3.3)
+                    (setf brake 3.3))
                 
                 ; Pass through throttle and brake to VESC
                 (app-adc-override 0 throttle)

--- a/m365_dash.lisp
+++ b/m365_dash.lisp
@@ -81,17 +81,17 @@
 (defun adc-input(buffer) ; Frame 0x65
     {
         (let ((current-speed (* (get-speed) 3.6))
-            (throttle (/(bufget-u8 uart-buf 4) 255.0))
-            (brake (/(bufget-u8 uart-buf 5) 255.0)))
+            (throttle (/(bufget-u8 uart-buf 4) 77.2)) ; 255/3.3 = 77.2
+            (brake (/(bufget-u8 uart-buf 5) 77.2)))
             {
                 (if (< throttle 0)
                     (setf throttle 0))
-                (if (> throttle 1)
-                    (setf throttle 1))
+                (if (> throttle 3.3)
+                    (setf throttle 3.3))
                 (if (< brake 0)
                     (setf brake 0))
-                (if (> brake 1)
-                    (setf brake 1))
+                (if (> brake 3.3)
+                    (setf brake 3.3))
                 
                 ; Pass through throttle and brake to VESC
                 (app-adc-override 0 throttle)


### PR DESCRIPTION
since https://github.com/vedderb/bldc/commit/c5b8bb7febfc6e910c16a51ea279d19a425d5d37 values are no longer 0:1 but 0:3.3

connected to https://github.com/vedderb/bldc/issues/706