### PR TITLE
fix: zero current on CAN slaves at stop

### DIFF
--- a/scooter_support.lisp
+++ b/scooter_support.lisp
@@ -467,11 +467,7 @@
                     (app-adc-override 0 0)
                     (app-adc-override 1 0)
                     (app-disable-output -1)
-                    (set-current 0)
-                    ; rcode canset
-                    ;(loopforeach i (can-list-devs)
-                    ;    (canset-current i 0)
-                    ;)
+                    (stop-current)
                 }
             )
             (if (app-is-output-disabled) ; Enable output when scooter is turned on
@@ -846,6 +842,15 @@
         ; count up alarm state
         (if (> alarm 0)
             (set 'alarm (+ alarm 1))
+        )
+    }
+)
+
+(defun stop-current()
+    {
+        (set-current-rel 0)
+        (loopforeach id (can-list-devs)
+            (rcode-run-noret id '(set-current-rel 0))
         )
     }
 )


### PR DESCRIPTION
`app-disable-output -1` already cuts the output, but this fixes my comment from ages ago.